### PR TITLE
fix: ensure ClimbingEntity does not perform non-threadsafe calls to getBlockState

### DIFF
--- a/common/src/main/java/com/dayofpi/mobcatalog/entity/custom/ClimbingEntity.java
+++ b/common/src/main/java/com/dayofpi/mobcatalog/entity/custom/ClimbingEntity.java
@@ -2,6 +2,7 @@ package com.dayofpi.mobcatalog.entity.custom;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.stream.Stream;
@@ -10,17 +11,25 @@ public interface ClimbingEntity {
     boolean canClimbBlock(BlockState blockState);
 
     static boolean isClimbableBlockNearby(Entity entity) {
-        if (entity instanceof ClimbingEntity) {
+        if (entity instanceof ClimbingEntity climbingEntity) {
+            final Level level = entity.level();
+
             Stream<BlockPos> posList = BlockPos.withinManhattanStream(entity.blockPosition(), 2, 1, 2);
-            return posList.anyMatch(blockPos -> ((ClimbingEntity) entity).canClimbBlock(entity.level().getBlockState(blockPos)));
+            return posList.anyMatch(
+                (blockPos) -> level.isLoaded(blockPos) && climbingEntity.canClimbBlock(level.getBlockState(blockPos))
+            );
         }
         return false;
     }
 
     static boolean canClimb(Entity entity) {
-        if (entity instanceof ClimbingEntity) {
+        if (entity instanceof ClimbingEntity climbingEntity) {
+            final Level level = entity.level();
+
             Stream<BlockPos> posList = BlockPos.withinManhattanStream(entity.blockPosition(), 1, 0, 1);
-            return posList.anyMatch(blockPos -> blockPos.distToCenterSqr(entity.position()) < 1.3 && ((ClimbingEntity) entity).canClimbBlock(entity.level().getBlockState(blockPos)));
+            return posList.anyMatch(
+                (blockPos) -> blockPos.distToCenterSqr(entity.position()) < 1.3 && level.isLoaded(blockPos) && climbingEntity.canClimbBlock(level.getBlockState(blockPos))
+            );
         }
         return false;
     }


### PR DESCRIPTION
fixes #5